### PR TITLE
Update edit target docs inside Houdini and Maya

### DIFF
--- a/docs/source/prim_composition.rst
+++ b/docs/source/prim_composition.rst
@@ -23,7 +23,7 @@ Setting an Edit Target
 The ``Prim Composition`` tree exposes a context menu with a ``Set as Edit Target`` item.
 This redirect edits under the selected arc by setting the current stage's `Edit Target`_.
 
-In the examples below, prims under ``ChairB_2`` have their `displayColor`_, ``doc`` and ``active`` properties modified in ``USDView``, ``Houdini`` and ``Maya`` respectively, and changes are inspected via the ``Layer Content Browser`` view.
+In the examples below, prims under ``ChairB_2`` and ``CheerioA_164`` have their `displayColor`_, ``doc`` and ``active`` properties modified in ``USDView``, ``Houdini`` and ``Maya`` respectively, and changes are inspected via the ``Layer Content Browser`` view.
 
 .. tab:: USDView
 

--- a/docs/source/prim_composition.rst
+++ b/docs/source/prim_composition.rst
@@ -23,17 +23,43 @@ Setting an Edit Target
 The ``Prim Composition`` tree exposes a context menu with a ``Set as Edit Target`` item.
 This redirect edits under the selected arc by setting the current stage's `Edit Target`_.
 
-In the example below, `Mesh`_ prims under ``ChairB_2`` have their `displayColor`_ property modified:
+In the examples below, prims under ``ChairB_2`` have their `displayColor`_, ``doc`` and ``active`` properties modified in ``USDView``, ``Houdini`` and ``Maya`` respectively, and changes are inspected via the ``Layer Content Browser`` view.
 
-#. The reference arc targeting the ``Chair.geom.usd`` layer is set as `Edit Target`_.
+.. tab:: USDView
 
-   When `displayColor`_ is modified, the changes are visible on **both** ``ChairB_1`` **and** ``ChairB_2``, since they share the composition arc and the layer being modified.
+    #. The ``reference`` arc targeting the ``Chair.geom.usd`` layer is set as `Edit Target`_.
 
-#. The root arc targeting the ``Kitchen_set.usd`` layer is set as `Edit Target`_.
+       When `displayColor`_ is modified, the changes are visible on **both** ``ChairB_1`` **and** ``ChairB_2``, since they share the composition arc and the layer being modified.
 
-   Once the `displayColor`_ is modified, the changes are visible on ``ChairB_2`` **only**, since nothing else shares that arc.
+    #. The ``root`` arc targeting the ``Kitchen_set.usd`` layer is set as `Edit Target`_.
 
-.. image:: https://user-images.githubusercontent.com/8294116/156912114-a24b81f4-63b1-4b62-9d84-9e2c07aaef5c.gif
+       Once the `displayColor`_ is modified, the changes are visible on ``ChairB_2`` **only**, since nothing else shares that arc.
+
+    .. image:: https://user-images.githubusercontent.com/8294116/156912114-a24b81f4-63b1-4b62-9d84-9e2c07aaef5c.gif
+
+.. tab:: Houdini
+
+    #. The ``payload`` arc targeting the ``Cheerio_payload.usd`` layer is set as `Edit Target`_.
+
+       When ``doc`` of the ``CheerioA_164`` prim is modified, the changes are visible on **all** ``CheerioA_*`` prims, since they share the composition arc and the layer being modified.
+
+    #. The ``root`` arc targeting the anonymous houdini LOP layer is set as `Edit Target`_.
+
+       Once the ``doc`` is modified, the changes are visible on ``CheerioA_164`` **only**, since nothing else shares that arc.
+
+    .. image:: https://user-images.githubusercontent.com/8294116/158165374-fe42d80e-8d32-48a4-a628-f6255b5a9e55.gif
+
+.. tab:: Maya
+
+    #. The ``payload`` arc targeting the ``Chair_payload.usd`` layer is set as `Edit Target`_.
+
+       When ``active`` property is modified, the changes are visible on **both** ``ChairB_1`` **and** ``ChairB_2``, since they share the composition arc and the layer being modified.
+
+    #. The ``root`` arc targeting the ``Kitchen_set.usd`` layer is set as `Edit Target`_.
+
+       Once the ``active`` property is modified, the changes are visible on ``ChairB_2`` **only**, since nothing else shares that arc.
+
+    .. image:: https://user-images.githubusercontent.com/8294116/158165402-c1dd5119-fe78-4332-8ded-1495703345f9.gif
 
 .. _USD Prim: https://graphics.pixar.com/usd/docs/USD-Glossary.html#USDGlossary-Prim
 .. _composition arc details: https://graphics.pixar.com/usd/docs/USD-Glossary.html#USDGlossary-CompositionArcs


### PR DESCRIPTION
Added missing doc examples of edit target inside houdini and maya:

![edit_target_hou02](https://user-images.githubusercontent.com/8294116/158165374-fe42d80e-8d32-48a4-a628-f6255b5a9e55.gif)

![edit_target_maya02](https://user-images.githubusercontent.com/8294116/158165402-c1dd5119-fe78-4332-8ded-1495703345f9.gif)

