### PR TITLE
Maya-2023 and Houdini-19.5 Support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,11 +25,11 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest codecov pytest-cov
+          python -m pip install pytest pytest-cov
           python -m pip install ".[full,test]"
       - name: Test
         run: |
           pytest --cov=./ --cov-report xml
           codecov
       - name: Codecov Report
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,6 +30,5 @@ jobs:
       - name: Test
         run: |
           pytest --cov=./ --cov-report xml
-          codecov
       - name: Codecov Report
         uses: codecov/codecov-action@v3

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -46,7 +46,7 @@ Extra Dependencies
 
 The following optional dependencies should be installed separately.
 
-- `graphviz <http://graphviz.org/>`_ (for graph widgets).
+- `graphviz <http://graphviz.org/>`_ and `pygraphviz`_ for graph widgets. See conda example below for instructions.
 - `usdview <https://graphics.pixar.com/usd/docs/USD-Toolset.html#USDToolset-usdview>`_
   (hopefully will be available soon via `pypi <https://pypi.org/>`_). In the meantime, it can be built from USD source
   (`conda recipe <https://github.com/PixarAnimationStudios/USD/issues/1260#issuecomment-656985888>`_).
@@ -71,28 +71,56 @@ walk-through on how to start using ``The Grill`` tools with a fresh
 
 3. Create a new ``conda`` environment with ``python=3.9``, for example:
 
-   .. code:: bash
+   .. code:: PowerShell
 
       (base) C:\>conda create -n grilldemo01 python=3.9
 
 4. Activate that environment:
 
-   .. code:: bash
+   .. code:: PowerShell
 
       (base) C:\>conda activate grilldemo01
 
 5. Install ``grill`` via ``pip``; use the ``full`` option to use standalone.
    Refer to the `pip install instructions <#pip-install>`_ for more details.
 
-   .. code:: bash
+   .. code:: PowerShell
 
       (grilldemo01) C:\>python -m pip install grill[full]
 
-6. If missing, (optionally) install `pygraphviz <https://pygraphviz.github.io/documentation/stable/install.html>`_ via ``conda``:
+6. If missing, (optionally) install `pygraphviz`_ via ``conda``:
 
-   .. code:: bash
+   .. warning::
 
-      (grilldemo01) C:\>conda install --channel conda-forge pygraphviz
+      At the moment, installing pygraphviz can be tricky. Hopefully a simpler pip based solution comes with `pygraphviz#167 <https://github.com/pygraphviz/pygraphviz/issues/167>`_.
+
+   .. tab:: Standalone Python
+
+     Replace ``--global-option`` to the correct Include and Lib paths on the system:
+
+     .. code:: PowerShell
+
+        (grilldemo01) C:\>conda install --channel conda-forge pygraphviz
+        (grilldemo01) C:\>python -m pip install --global-option=build_ext --global-option="-IC:\Users\Christian\.conda\envs\glowdeps\Library\include" --global-option="-LC:\Users\Christian\.conda\envs\glowdeps\Library\lib" pygraphviz
+
+   .. tab:: Houdini
+
+     Replace ``--global-option`` to the correct Include and Lib paths on the system:
+
+     .. code:: PowerShell
+
+        (grilldemo01) C:\>conda install --channel conda-forge pygraphviz
+        (grilldemo01) C:\Program Files\Side Effects Software\Houdini 19.5.534\bin>hython -m pip install --global-option=build_ext --global-option="-IC:\Users\Christian\.conda\envs\glowdeps\Library\include" --global-option="-LC:\Users\Christian\.conda\envs\glowdeps\Library\lib" pygraphviz
+
+   .. tab:: Maya
+
+     Replace ``--global-option`` to the correct Include and Lib paths on the system **and** the Maya Python include and lib paths:
+
+     .. code:: PowerShell
+
+        (grilldemo01) C:\>conda install --channel conda-forge pygraphviz
+        (grilldemo01) C:\Program Files\Autodesk\Maya2023\bin>mayapy -m pip install --global-option=build_ext  --global-option="-IC:\Users\Christian\.conda\envs\glowdeps\Library\include;C:\Program Files\Autodesk\Maya2023\include\Python39\Python" --global-option="-LC:\Users\Christian\.conda\envs\glowdeps\Library\lib;C:\Program Files\Autodesk\Maya2023\lib" pygraphviz
+
 
 7. You should be able to see the ``👨‍🍳 Grill`` menu in **USDView**, **Maya** and **Houdini***.
 
@@ -114,10 +142,11 @@ walk-through on how to start using ``The Grill`` tools with a fresh
 
         .. code:: bash
 
-            hython3.7.exe -c "from grill.__startup__ import houdini;houdini.install_package()"
+            hython -c "from grill.__startup__ import houdini;houdini.install_package()"
 
         The manual execution of this step might be removed in the future.
 
+.. _pygraphviz: https://pygraphviz.github.io/documentation/stable/install.html
 .. _miniconda: https://docs.conda.io/en/latest/miniconda.html
 .. _Anaconda: https://docs.anaconda.com/anaconda/user-guide/getting-started/
 .. _conda: https://docs.conda.io/projects/conda/en/latest/index.html

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -96,7 +96,7 @@ walk-through on how to start using ``The Grill`` tools with a fresh
 
    .. tab:: Standalone Python
 
-     Replace ``--global-option`` to the correct Include and Lib paths on the system:
+     Replace ``--global-option`` to the correct ``Include`` and ``Lib`` paths on the system (where ``graphviz\cgraph.h`` and ``cgraph.lib`` paths exist, respectively):
 
      .. code:: PowerShell
 
@@ -105,7 +105,7 @@ walk-through on how to start using ``The Grill`` tools with a fresh
 
    .. tab:: Houdini
 
-     Replace ``--global-option`` to the correct Include and Lib paths on the system:
+     Replace ``--global-option`` to the correct ``Include`` and ``Lib`` paths on the system (where ``graphviz\cgraph.h`` and ``cgraph.lib`` paths exist, respectively):
 
      .. code:: PowerShell
 
@@ -114,7 +114,7 @@ walk-through on how to start using ``The Grill`` tools with a fresh
 
    .. tab:: Maya
 
-     Replace ``--global-option`` to the correct Include and Lib paths on the system **and** the Maya Python include and lib paths:
+     Replace ``--global-option`` to the correct ``Include`` and ``Lib`` paths on the system (where ``graphviz\cgraph.h`` and ``cgraph.lib`` paths exist, respectively) **and** the Maya Python ``include`` and ``lib`` paths:
 
      .. code:: PowerShell
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -30,7 +30,7 @@ DCC apps and other environments bundle them outside of ``pip``. To include them,
 
         .. code-block:: bash
 
-            hython3.7 -m pip install grill
+            hython -m pip install grill
 
     .. tab:: Maya
 
@@ -39,11 +39,6 @@ DCC apps and other environments bundle them outside of ``pip``. To include them,
         .. code-block:: bash
 
             mayapy -m pip install grill
-
-
-.. warning::
-
-    Some DCC applications like **Houdini-19** and **Maya-2022** are still on ``python-3.7``, so installing ``grill`` for those applications will require ``grill<0.13.0``.
 
 
 Extra Dependencies
@@ -93,11 +88,11 @@ walk-through on how to start using ``The Grill`` tools with a fresh
 
       (grilldemo01) C:\>python -m pip install grill[full]
 
-6. If missing, (optionally) install ``graphviz`` via ``conda``:
+6. If missing, (optionally) install `pygraphviz <https://pygraphviz.github.io/documentation/stable/install.html>`_ via ``conda``:
 
    .. code:: bash
 
-      (grilldemo01) C:\>conda install -c anaconda graphviz
+      (grilldemo01) C:\>conda install --channel conda-forge pygraphviz
 
 7. You should be able to see the ``👨‍🍳 Grill`` menu in **USDView**, **Maya** and **Houdini***.
 

--- a/docs/source/layer_content_browser.rst
+++ b/docs/source/layer_content_browser.rst
@@ -7,7 +7,7 @@ Array attributes and time samples have their contents reduced to a maximum of 6 
 
 The following example browses the contents of the layers that modify the ``displayColor`` property of the ``ChairB_2`` (as presented on :ref:`Setting an Edit Target`).
 
-.. image:: https://user-images.githubusercontent.com/8294116/156912106-4526e7be-f846-4daa-8095-ae67440bd9ad.gif
+.. image:: https://user-images.githubusercontent.com/8294116/231415967-c960d036-05e6-42d3-905f-d673f8cf2579.gif
 
 The ``Layer Content Browser`` widget can be opened from the USDView ``Composition`` tab (as shown above), as well as from the layer tree of the :ref:`Layer Stack Composition` widget:
 

--- a/docs/source/layer_content_browser.rst
+++ b/docs/source/layer_content_browser.rst
@@ -1,11 +1,9 @@
 Layer Content Browser
 ---------------------
 
-Uses `sdffilter`_ to display content from USD layers (regardless of format or if they have been saved on disk).
+Uses `sdffilter`_ and `usdtree`_ to display content from USD layers (regardless of format or if they have been saved on disk).
 
 Array attributes and time samples have their contents reduced to a maximum of 6 entries.
-
-The following example browses the contents of the layers that modify the ``displayColor`` property of the ``ChairB_2`` (as presented on :ref:`Setting an Edit Target`).
 
 .. image:: https://user-images.githubusercontent.com/8294116/231415967-c960d036-05e6-42d3-905f-d673f8cf2579.gif
 
@@ -13,4 +11,5 @@ The ``Layer Content Browser`` widget can be opened from the USDView ``Compositio
 
 .. image:: https://user-images.githubusercontent.com/8294116/156912110-a573d9a6-6aed-4b8a-b492-dbaad2613283.gif
 
-.. _sdffilter: https://graphics.pixar.com/usd/release/toolset.html#sdffilter
+.. _sdffilter: https://openusd.org/release/toolset.html#sdffilter
+.. _usdtree: https://openusd.org/release/toolset.html#usdtree

--- a/docs/source/prim_composition.rst
+++ b/docs/source/prim_composition.rst
@@ -10,7 +10,7 @@ To visualize the composition graph, the ``graphviz`` library needs to be availab
 
 .. tab:: Houdini
 
-    .. image:: https://user-images.githubusercontent.com/8294116/98945804-1dee6300-2547-11eb-8e9b-3f0211af6f3c.gif
+    .. image:: https://user-images.githubusercontent.com/8294116/223416152-d7c456d1-6995-48e4-93e0-a89f89200d4e.gif
 
 .. tab:: Maya
 

--- a/grill/cook/__init__.py
+++ b/grill/cook/__init__.py
@@ -22,6 +22,7 @@
         WindowsPath('C:/Users/CHRIST~1/AppData/Local/Temp/tmp767wqaya')
 
 """
+from __future__ import annotations
 
 import types
 import typing

--- a/grill/resources/houdini/MainMenuCommon.xml
+++ b/grill/resources/houdini/MainMenuCommon.xml
@@ -35,6 +35,11 @@ houdini._prim_composition().show()]]></scriptCode>
 houdini._layerstack_composition().show()]]></scriptCode>
             </scriptItem>
 
+            <scriptItem id="stage_stats">
+                <label>Stage Stats</label>
+                <scriptCode><![CDATA[from grill.views import houdini
+houdini._stage_stats().show()]]></scriptCode>
+            </scriptItem>
         </subMenu>
     </menuBar>
 </mainMenu>

--- a/grill/views/_core.py
+++ b/grill/views/_core.py
@@ -116,8 +116,7 @@ def _which(what):
 @cache
 def _ensure_dot():
     """For usage only when DCC python interpreter fails to install pygraphviz properly."""
-    dotpath = _which("dot")
-    if dotpath:
+    if dotpath := _which("dot"):
         # https://github.com/pygraphviz/pygraphviz/issues/360
         # TODO: is this the best approach to solve current Houdini and Maya failing to import graphviz??
         os.add_dll_directory(Path(dotpath).parent)  # sigh, patch pygraphviz?

--- a/grill/views/_core.py
+++ b/grill/views/_core.py
@@ -119,7 +119,8 @@ def _ensure_dot():
     if dotpath := _which("dot"):
         # https://github.com/pygraphviz/pygraphviz/issues/360
         # TODO: is this the best approach to solve current Houdini and Maya failing to import graphviz??
-        os.add_dll_directory(Path(dotpath).parent)  # sigh, patch pygraphviz?
+        if hasattr(os, "add_dll_directory"):
+            os.add_dll_directory(Path(dotpath).parent)  # sigh, patch pygraphviz?
 
 
 @contextlib.contextmanager

--- a/grill/views/_core.py
+++ b/grill/views/_core.py
@@ -81,31 +81,6 @@ QTableView::item:hover:!pressed:selected {
 /*    background: rgb(132, 109, 59); */
     background: rgb(227, 186, 101);
 }
-
-/* Set the branch triangle icons */
-_Tree::branch:has-children:!has-siblings:closed,
-_Tree::branch:closed:has-children:has-siblings {
-    border-image: none;
-    image: url(%(RESOURCE_DIR)s/icons/branch-closed.png);
-}
-
-_Tree::branch:open:has-children:!has-siblings,
-_Tree::branch:open:has-children:has-siblings  {
-    border-image: none;
-    image: url(%(RESOURCE_DIR)s/icons/branch-open.png);
-}
-
-_Tree::branch:selected:has-children:!has-siblings:closed,
-_Tree::branch:selected:closed:has-children:has-siblings {
-    border-image: none;
-    image: url(%(RESOURCE_DIR)s/icons/branch-closed-selected.png);
-}
-
-_Tree::branch:selected:open:has-children:!has-siblings,
-_Tree::branch:selected:open:has-children:has-siblings  {
-    border-image: none;
-    image: url(%(RESOURCE_DIR)s/icons/branch-open-selected.png);
-}
 """
 
 @cache
@@ -299,6 +274,7 @@ class _Header(QtWidgets.QHeaderView):
             proxy_label.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
             self._proxy_labels[column_options.label] = proxy_label
 
+        self.setStretchLastSection(True)
         self.setSectionsMovable(True)
         self.sectionResized.connect(self._handleSectionResized)
         self.sectionMoved.connect(self._handleSectionMoved)

--- a/grill/views/_core.py
+++ b/grill/views/_core.py
@@ -116,28 +116,29 @@ def wait():
 
 
 class _EMOJI(enum.Enum):  # Replace with StrEnum in 3.11
+    # All emojis have an additional space at the end since Maya-2023.2 and Houdini-19.5 are unable to display emoji otherwise
     # GENERAL
-    ID = "🕵"
-    VISIBILITY = "👀"
-    SEARCH = "🔎"
-    LOCK = "🔐"
-    UNLOCK = "🔓"
+    ID = "🕵 "
+    VISIBILITY = "👀 "
+    SEARCH = "🔎 "
+    LOCK = "🔐 "
+    UNLOCK = "🔓 "
 
     # STAGE TRAVERSAL
-    MODEL_HIERARCHY = "🏡"
-    INSTANCE_PROXIES = "💠"
+    MODEL_HIERARCHY = "🏡 "
+    INSTANCE_PROXIES = "💠 "
 
     # PRIM SPECIFIER
-    ORPHANED = "👻"
-    CLASSES = "🧪"
-    DEFINED = "🧱"
+    ORPHANED = "👻 "
+    CLASSES = "🧪 "
+    DEFINED = "🧱 "
 
     # PRIM STATUS
-    ACTIVE = "💡"
-    INACTIVE = "🌒"
+    ACTIVE = "💡 "
+    INACTIVE = "🌒 "
 
     # IDENTIFICATION
-    NAME = "🔖"
+    NAME = "🔖 "
 
 
 class _Column(typing.NamedTuple):

--- a/grill/views/_core.py
+++ b/grill/views/_core.py
@@ -1,8 +1,11 @@
 """Shared members for views modules, not considered public API."""
+import os
 import enum
+import shutil
 import typing
 import contextlib
-from functools import partial
+from pathlib import Path
+from functools import partial, cache
 
 from ._qt import QtWidgets, QtGui, QtCore
 
@@ -104,6 +107,20 @@ _Tree::branch:selected:open:has-children:has-siblings  {
     image: url(%(RESOURCE_DIR)s/icons/branch-open-selected.png);
 }
 """
+
+@cache
+def _which(what):
+    return shutil.which(what)
+
+
+@cache
+def _ensure_dot():
+    """For usage only when DCC python interpreter fails to install pygraphviz properly."""
+    dotpath = _which("dot")
+    if dotpath:
+        # https://github.com/pygraphviz/pygraphviz/issues/360
+        # TODO: is this the best approach to solve current Houdini and Maya failing to import graphviz??
+        os.add_dll_directory(Path(dotpath).parent)  # sigh, patch pygraphviz?
 
 
 @contextlib.contextmanager

--- a/grill/views/_qt.py
+++ b/grill/views/_qt.py
@@ -2,6 +2,15 @@ try:  # only while transition from PySide2 to PySide6 happens
     from PySide6 import QtWidgets, QtGui, QtCore, QtWebEngineWidgets, QtCharts
 except ImportError:
     from PySide2 import QtWidgets, QtGui, QtCore, QtWebEngineWidgets
+    if not hasattr(QtCore, "__enter__"):
+        class SignalBlocker(QtCore.QSignalBlocker):
+            def __enter__(self):
+                yield
+
+            def __exit__(self, exc_type, exc_value, exc_traceback):
+                self.unblock()
+
+        QtCore.QSignalBlocker = SignalBlocker
     try:
         from PySide2.QtCharts import QtCharts
     except ImportError:

--- a/grill/views/_qt.py
+++ b/grill/views/_qt.py
@@ -2,4 +2,8 @@ try:  # only while transition from PySide2 to PySide6 happens
     from PySide6 import QtWidgets, QtGui, QtCore, QtWebEngineWidgets, QtCharts
 except ImportError:
     from PySide2 import QtWidgets, QtGui, QtCore, QtWebEngineWidgets
-    from PySide2.QtCharts import QtCharts
+    try:
+        from PySide2.QtCharts import QtCharts
+    except ImportError:
+        # Maya-2023.3 and Houdini-19.5.534 bundle PySide2, but their versions fail to bring QtCharts :c
+        pass

--- a/grill/views/description.py
+++ b/grill/views/description.py
@@ -606,7 +606,14 @@ class _PseudoUSDBrowser(QtWidgets.QTabWidget):
         try:
             focus_widget = self._browsers_by_layer[layer]
         except KeyError:
-            paths_in_layer = [path for path in paths if layer.GetObjectAtPath(path)]
+            paths_in_layer = []
+            for path in paths:
+                if not layer.GetObjectAtPath(path):
+                    print(f"{path=} does not exist on {layer=}")
+                    continue
+                if path.IsPropertyPath():
+                    path = path.GetParentPath()
+                paths_in_layer.append(path)
             error, text = _browse_layer_contents(layer, paths=paths_in_layer)
             if error:
                 QtWidgets.QMessageBox.warning(self, "Error Opening Contents", error)

--- a/grill/views/description.py
+++ b/grill/views/description.py
@@ -645,8 +645,12 @@ class _PseudoUSDBrowser(QtWidgets.QTabWidget):
                     variant_set, selection = path.GetVariantSelection()
                     if path.IsPrimVariantSelectionPath() and selection:  # place all variant selections under the variant set
                         parent_key = parent_key.AppendVariantSelection(variant_set, "")
+                    highlight_color = _HIGHLIGHT_COLORS["variantSets"][_PALETTE.get()] if variant_set else None
                     parent = items[parent_key] if parent_key in items else root_item
                     new_items = [QtGui.QStandardItem(str(column.getter(path))) for column in outliner_columns]
+                    if highlight_color:
+                        for item in new_items:
+                            item.setData(highlight_color, QtCore.Qt.ForegroundRole)
                     parent.appendRow(new_items)
                     new_items[0].setData(path, QtCore.Qt.UserRole)
                     items[path] = new_items[0]

--- a/grill/views/description.py
+++ b/grill/views/description.py
@@ -415,7 +415,7 @@ class PrimComposition(QtWidgets.QDialog):
         tree_controls_layout = QtWidgets.QHBoxLayout()
         tree_controls.setLayout(tree_controls_layout)
         self._prim = None  # TODO: see if we can remove this. Atm needed for "enabling layer stack" checkbox
-        self._complete_target_layerstack = QtWidgets.QCheckBox("Complete Target LayerStackz")
+        self._complete_target_layerstack = QtWidgets.QCheckBox("Complete Target LayerStack")
         self._complete_target_layerstack.setChecked(False)
         self._complete_target_layerstack.clicked.connect(lambda: self.setPrim(self._prim))
         tree_controls_layout.addWidget(self._complete_target_layerstack)

--- a/grill/views/description.py
+++ b/grill/views/description.py
@@ -441,7 +441,9 @@ class PrimComposition(QtWidgets.QDialog):
         self._prim = prim
         if not self._prim:
             self.clear()
+            self.setWindowTitle("Prim Composition")
             return
+        self.setWindowTitle(f"Prim Composition: {prim.GetName()} ({prim.GetPath()})")
         prim_index = prim.GetPrimIndex()
         self.index_box.setText(prim_index.DumpToString())
         fd, fp = tempfile.mkstemp()

--- a/grill/views/description.py
+++ b/grill/views/description.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import re
-import shutil
 import typing
 import operator
 import tempfile
@@ -22,6 +21,7 @@ from ._qt import QtWidgets, QtGui, QtCore, QtWebEngineWidgets
 
 from .. import usd as _usd
 from . import sheets as _sheets, _core
+from ._core import _which
 
 
 _color_attrs = lambda color: dict.fromkeys(("color", "fontcolor"), color)
@@ -60,9 +60,7 @@ _HIGHLIGHT_PATTERN = re.compile(
 )
 
 
-@lru_cache(maxsize=None)
-def _which(what):
-    return shutil.which(what)
+
 
 
 def _run(args: list):

--- a/grill/views/houdini.py
+++ b/grill/views/houdini.py
@@ -1,13 +1,9 @@
 import hou
 import toolutils
 from functools import cache, lru_cache, partial
-# pygraphviz required vvvvvvvvvvvv
-# https://github.com/pygraphviz/pygraphviz/issues/360
-import os
-os.add_dll_directory(r"C:\Users\Christian\.conda\envs\glowdeps\Library\bin")  # sigh, patch pygraphviz?
-# pygraphviz required ^^^^^^^^^^^^
-from . import sheets as _sheets, description as _description, create as _create, stats as _stats
+from . import sheets as _sheets, description as _description, create as _create, stats as _stats, _core
 _description._PALETTE.set(0)  # (0 == dark, 1 == light)
+_core._ensure_dot()
 
 
 def _stage_on_widget(widget_creator, _cache=True):

--- a/grill/views/houdini.py
+++ b/grill/views/houdini.py
@@ -1,13 +1,17 @@
 import hou
 import toolutils
 from functools import cache, lru_cache, partial
-
-from . import sheets as _sheets, description as _description, create as _create
+# pygraphviz required vvvvvvvvvvvv
+# https://github.com/pygraphviz/pygraphviz/issues/360
+import os
+os.add_dll_directory(r"C:\Users\Christian\.conda\envs\glowdeps\Library\bin")  # sigh, patch pygraphviz?
+# pygraphviz required ^^^^^^^^^^^^
+from . import sheets as _sheets, description as _description, create as _create, stats as _stats
 _description._PALETTE.set(0)  # (0 == dark, 1 == light)
 
 
-def _stage_on_widget(widget_creator):
-    @cache
+def _stage_on_widget(widget_creator, _cache=True):
+    _description._PALETTE.set(0)  # (0 == dark, 1 == light)
     def _launcher():
         widget = widget_creator(parent=hou.qt.mainWindow())
         # TODO: Get stage from current node or from current viewport?
@@ -19,6 +23,8 @@ def _stage_on_widget(widget_creator):
 
         return widget
 
+    if _cache:
+        _launcher = cache(_launcher)
     return _launcher
 
 
@@ -54,6 +60,7 @@ def _spreadsheet():
 
 
 def _prim_composition():
+    _description._PALETTE.set(0)  # (0 == dark, 1 == light)
     editor = _description.PrimComposition(parent=hou.qt.mainWindow())
     editor._prim = None
 
@@ -84,3 +91,4 @@ def _prim_composition():
 _create_assets = partial(_creator, _create.CreateAssets)
 _taxonomy_editor = partial(_creator, _create.TaxonomyEditor)
 _layerstack_composition = _stage_on_widget(_description.LayerStackComposition)
+_stage_stats = _stage_on_widget(_stats.StageStats, _cache=False)

--- a/grill/views/maya.py
+++ b/grill/views/maya.py
@@ -9,7 +9,7 @@ import mayaUsd
 import maya.OpenMayaUI as omui
 import maya.api.OpenMaya as om
 
-from . import description as _description, sheets as _sheets, create as _create, _core
+from . import description as _description, sheets as _sheets, create as _create, _core, stats as _stats
 _description._PALETTE.set(0)  # (0 == dark, 1 == light)
 
 
@@ -18,8 +18,7 @@ def _main_window():
     return wrapInstance(int(omui.MQtUtil.mainWindow()), QtWidgets.QWidget)
 
 
-def _stage_on_widget(widget_creator):
-    @cache
+def _stage_on_widget(widget_creator, _cache=True):
     def _launcher():
         widget = widget_creator(parent=_main_window())
         widget.setStyleSheet(
@@ -35,6 +34,8 @@ def _stage_on_widget(widget_creator):
         if stage:
             widget.setStage(stage)
         return widget
+    if _cache:
+        _launcher = cache(_launcher)
     return _launcher
 
 
@@ -70,6 +71,7 @@ def create_menu():
             ("Spreadsheet Editor", _stage_on_widget(_sheets.SpreadsheetEditor)),
             ("Prim Composition", _prim_composition),
             ("LayerStack Composition", _stage_on_widget(_description.LayerStackComposition)),
+            ("Stage Stats", _stage_on_widget(_stats.StageStats, _cache=False)),
     ):
         cmds.menuItem(title, command=partial(show, launcher), parent=menu)
 

--- a/grill/views/maya.py
+++ b/grill/views/maya.py
@@ -11,6 +11,7 @@ import maya.api.OpenMaya as om
 
 from . import description as _description, sheets as _sheets, create as _create, _core, stats as _stats
 _description._PALETTE.set(0)  # (0 == dark, 1 == light)
+_core._ensure_dot()
 
 
 @cache

--- a/grill/views/stats.py
+++ b/grill/views/stats.py
@@ -33,10 +33,6 @@ class _ContainerTree(QtWidgets.QTreeWidget):
 
 
 class _StatsPie(QtWidgets.QWidget):
-    def __init__(self, *args, stats=None, **kwargs):
-        super().__init__(*args, **kwargs)
-        if stats:
-            self.setStats(stats)
 
     def setStats(self, value, *, title=None):
         layout = QtWidgets.QVBoxLayout()

--- a/grill/views/stats.py
+++ b/grill/views/stats.py
@@ -1,7 +1,12 @@
-from functools import partial
+from functools import partial, cache
 from pxr import UsdUtils
 
-from ._qt import QtWidgets, QtCore, QtCharts, QtGui
+from ._qt import QtWidgets, QtCore, QtGui
+
+
+@cache
+def _report_no_charts():
+    print("No QtCharts module could be imported. Are you in a DCC app?")
 
 
 class _ContainerTree(QtWidgets.QTreeWidget):
@@ -47,7 +52,12 @@ class _StatsPie(QtWidgets.QWidget):
                 target = substats if isinstance(data_value, dict) else stats
                 target.append((data_key, data_value))
 
-            if stats:
+            def _add_pie():
+                try:
+                    from ._qt import QtCharts  # Hou-19.5 & Maya-2023 don't include QtCharts
+                except ImportError:
+                    _report_no_charts()
+                    return
                 series = QtCharts.QPieSeries()
                 for stat_key, stat_value in stats:
                     series.append(f"{stat_key}: {stat_value}", stat_value)
@@ -63,6 +73,9 @@ class _StatsPie(QtWidgets.QWidget):
                 view = QtCharts.QChartView(chart)
                 view.setRenderHint(QtGui.QPainter.Antialiasing)
                 parent.addWidget(view)
+
+            if stats:
+                _add_pie()
 
             if substats:
                 subparent = QtWidgets.QSplitter(QtCore.Qt.Horizontal)

--- a/grill/views/usdview.py
+++ b/grill/views/usdview.py
@@ -80,6 +80,8 @@ class GrillContentBrowserLayerMenuItem(layerStackContextMenu.LayerStackContextMe
 
     def RunCommand(self):
         if self._item:
+            # from testing, only entries in the Composition tab without HasSpecs miss "path"
+            paths = [path] if (path := getattr(self._item, "path", None)) else []
             usdview_api = _usdview_api.get()
             context = usdview_api.stage.GetPathResolverContext()
             if not (layer:= getattr(self._item, 'layer', None)):  # USDView allows for single layer selection in composition tab :(
@@ -89,7 +91,7 @@ class GrillContentBrowserLayerMenuItem(layerStackContextMenu.LayerStackContextMe
                     if not (layer:=Sdf.Layer.FindOrOpen(layerPath)):  # edge case, is this possible?
                         print(f"Could not find layer from {layerPath}")
                         return
-            _description._launch_content_browser([layer], usdview_api.qMainWindow, context)
+            _description._launch_content_browser([layer], usdview_api.qMainWindow, context, paths=paths)
 
 
 class GrillPrimCompositionMenuItem(primContextMenuItems.PrimContextMenuItem):

--- a/grill/views/usdview.py
+++ b/grill/views/usdview.py
@@ -81,7 +81,12 @@ class GrillContentBrowserLayerMenuItem(layerStackContextMenu.LayerStackContextMe
     def RunCommand(self):
         if self._item:
             # from testing, only entries in the Composition tab without HasSpecs miss "path"
-            paths = [path] if (path := getattr(self._item, "path", None)) else []
+            if path := getattr(self._item, "path", None):
+                if isinstance(path, str):
+                    path = Sdf.Path(path)
+                paths = [path]
+            else:
+                paths = []
             usdview_api = _usdview_api.get()
             context = usdview_api.stage.GetPathResolverContext()
             if not (layer:= getattr(self._item, 'layer', None)):  # USDView allows for single layer selection in composition tab :(

--- a/grill/views/usdview.py
+++ b/grill/views/usdview.py
@@ -85,10 +85,11 @@ class GrillContentBrowserLayerMenuItem(layerStackContextMenu.LayerStackContextMe
 
 class GrillPrimCompositionMenuItem(primContextMenuItems.PrimContextMenuItem):
     def GetText(self):
-        return "Inspect Prim Composition"
+        return f"Inspect Prim{'s' if len(self._selectionDataModel.getPrims())>1 else ''} Composition"
 
     def RunCommand(self):
         usdview_api = _usdview_api.get()
+        # The "double pop up" upon showing widgets does not happen on PySide2, only on PySide6
         for prim in self._selectionDataModel.getPrims():
             widget = _description.PrimComposition(parent=usdview_api.qMainWindow)
             widget.setStyleSheet(_core._USDVIEW_QTREEVIEW_STYLE)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ include = grill.*
 
 [options.extras_require]
 # use a custom version of sphinx to workaround https://github.com/thegrill/grill-names/issues/6
-# test a soon to be released sphinx-hoverxref branch to support intersphinx https://github.com/readthedocs/sphinx-hoverxref/pull/86
 # python -m pip install -U git+https://github.com/thegrill/sphinx.git@grill-intersphinx-uniqueref-fix
 # For a dev install:
 # conda install --channel conda-forge pygraphviz

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -96,7 +96,7 @@ class TestViews(unittest.TestCase):
 
     def tearDown(self) -> None:
         cook.Repository.reset(self._token)
-        shutil.rmtree(self._tmpf)
+        # shutil.rmtree(self._tmpf)
 
     def test_layer_composition(self):
         widget = description.LayerStackComposition()
@@ -152,6 +152,12 @@ class TestViews(unittest.TestCase):
         widget._complete_target_layerstack.setChecked(True)
 
         self.assertTrue(widget.composition_tree._model.invisibleRootItem().hasChildren())
+
+        with mock.patch("grill.views.description.QtWidgets.QApplication.keyboardModifiers") as patch:
+            patch.return_value = QtCore.Qt.ShiftModifier
+            root_idx = widget.composition_tree._model.index(0, 0)
+            widget.composition_tree.expanded.emit(root_idx)
+            widget.composition_tree.collapsed.emit(root_idx)
 
         widget.setPrim(None)
         self.assertFalse(widget.composition_tree._model.invisibleRootItem().hasChildren())

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -388,7 +388,7 @@ class TestViews(unittest.TestCase):
             dialog = description._start_content_browser(*args)
             browser = dialog.findChild(description._PseudoUSDBrowser)
             browser._on_identifier_requested(anchor, layers[1].identifier)
-            with mock.patch("PySide6.QtWidgets.QMessageBox.warning", new=_log):
+            with mock.patch("PySide2.QtWidgets.QMessageBox.warning", new=_log):
                 browser._on_identifier_requested(anchor, "/missing/file.usd")
             browser.tabCloseRequested.emit(0)  # request closing our first tab
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -366,7 +366,7 @@ class TestViews(unittest.TestCase):
 
         # sdffilter still not coming via pypi, so patch for now
         if not description._which("sdffilter"):
-            def _to_ascii(layer):
+            def _to_ascii(layer, *args, **kwargs):
                 return "", layer.ExportToString()
         else:
             _to_ascii = description._browse_layer_contents

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -369,7 +369,7 @@ class TestViews(unittest.TestCase):
             def _to_ascii(layer, *args, **kwargs):
                 return "", layer.ExportToString()
         else:
-            _to_ascii = description._browse_layer_contents
+            _to_ascii = description._format_layer_contents
 
         layers = stage.GetLayerStack()
         args = stage.GetLayerStack(), None, stage.GetPathResolverContext()
@@ -378,7 +378,7 @@ class TestViews(unittest.TestCase):
         def _log(*args):
             print(args)
 
-        with mock.patch("grill.views.description._browse_layer_contents", new=_to_ascii):
+        with mock.patch("grill.views.description._format_layer_contents", new=_to_ascii):
             dialog = description._start_content_browser(*args)
             browser = dialog.findChild(description._PseudoUSDBrowser)
             browser._on_identifier_requested(anchor, layers[1].identifier)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -97,7 +97,7 @@ class TestViews(unittest.TestCase):
 
     def tearDown(self) -> None:
         cook.Repository.reset(self._token)
-        # shutil.rmtree(self._tmpf)
+        shutil.rmtree(self._tmpf)
 
     def test_layer_composition(self):
         widget = description.LayerStackComposition()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -369,7 +369,14 @@ class TestViews(unittest.TestCase):
         ):
             spawned = UsdGeom.Xform(cook.spawn_unit(parent, child, path))
             spawned.AddTranslateOp().Set(value=value)
-
+        variant_set_name = "testset"
+        variant_name = "testvar"
+        vset = child.GetVariantSet(variant_set_name)
+        vset.AddVariant(variant_name)
+        vset.SetVariantSelection(variant_name)
+        with vset.GetVariantEditContext():
+            stage.DefinePrim(child.GetPath().AppendChild("in_variant"))
+        path_with_variant = child.GetPath().AppendVariantSelection(variant_set_name, variant_name)
         # sdffilter still not coming via pypi, so patch for now
         if not description._which("sdffilter"):
             def _to_ascii(layer, *args, **kwargs):
@@ -378,7 +385,7 @@ class TestViews(unittest.TestCase):
             _to_ascii = description._format_layer_contents
 
         layers = stage.GetLayerStack()
-        args = stage.GetLayerStack(), None, stage.GetPathResolverContext(), (Sdf.Path("/"), spawned.GetPrim().GetPath(),)
+        args = stage.GetLayerStack(), None, stage.GetPathResolverContext(), (Sdf.Path("/"), spawned.GetPrim().GetPath(), path_with_variant)
         anchor = layers[0]
 
         def _log(*args):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -369,7 +369,7 @@ class TestViews(unittest.TestCase):
             def _to_ascii(layer):
                 return "", layer.ExportToString()
         else:
-            _to_ascii = description._pseudo_layer
+            _to_ascii = description._browse_layer_contents
 
         layers = stage.GetLayerStack()
         args = stage.GetLayerStack(), None, stage.GetPathResolverContext()
@@ -378,7 +378,7 @@ class TestViews(unittest.TestCase):
         def _log(*args):
             print(args)
 
-        with mock.patch("grill.views.description._pseudo_layer", new=_to_ascii):
+        with mock.patch("grill.views.description._browse_layer_contents", new=_to_ascii):
             dialog = description._start_content_browser(*args)
             browser = dialog.findChild(description._PseudoUSDBrowser)
             browser._on_identifier_requested(anchor, layers[1].identifier)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -127,21 +127,18 @@ class TestViews(unittest.TestCase):
         self.assertEqual(2, widget._layers.model.rowCount())
         self.assertEqual(1, widget._prims.model.rowCount())
 
-        if hasattr(os, "add_dll_directory"):  # add_dll_directory only on Windows
-            os_dll_ctx = contextlib.nullcontext()
-        else:
-            os_dll_ctx = mock.patch("os.add_dll_directory", new=lambda path: print(f"Added {path}"))
+        # add_dll_directory only on Windows
+        os.add_dll_directory = lambda path: print(f"Added {path}") if not hasattr(os, "add_dll_directory") else os.add_dll_directory
 
-        with os_dll_ctx:
-            _core._which.cache_clear()
-            with mock.patch("grill.views.description._which") as patch:  # simulate dot is not in the environment
-                patch.return_value = None
-                widget._graph_view.view([0,1])
+        _core._which.cache_clear()
+        with mock.patch("grill.views.description._which") as patch:  # simulate dot is not in the environment
+            patch.return_value = None
+            widget._graph_view.view([0,1])
 
-            _core._which.cache_clear()
-            with mock.patch("grill.views.description.nx.nx_agraph.write_dot") as patch:  # simulate pygraphviz is not installed
-                patch.side_effect = ImportError
-                widget._graph_view.view([0])
+        _core._which.cache_clear()
+        with mock.patch("grill.views.description.nx.nx_agraph.write_dot") as patch:  # simulate pygraphviz is not installed
+            patch.side_effect = ImportError
+            widget._graph_view.view([0])
 
         widget.deleteLater()
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -96,7 +96,7 @@ class TestViews(unittest.TestCase):
 
     def tearDown(self) -> None:
         cook.Repository.reset(self._token)
-        shutil.rmtree(self._tmpf)
+        # shutil.rmtree(self._tmpf)
 
     def test_layer_composition(self):
         widget = description.LayerStackComposition()
@@ -387,8 +387,13 @@ class TestViews(unittest.TestCase):
         with mock.patch("grill.views.description._format_layer_contents", new=_to_ascii):
             dialog = description._start_content_browser(*args)
             browser = dialog.findChild(description._PseudoUSDBrowser)
+            assert browser._browsers_by_layer.values()
+            first_browser_widget, = browser._browsers_by_layer.values()
+            first_browser_widget._format_options.setCurrentIndex(0)
+            first_browser_widget._format_options.setCurrentIndex(1)
+            first_browser_widget._format_options.setCurrentIndex(0)
             browser._on_identifier_requested(anchor, layers[1].identifier)
-            with mock.patch("PySide2.QtWidgets.QMessageBox.warning", new=_log):
+            with mock.patch("PySide6.QtWidgets.QMessageBox.warning", new=_log):
                 browser._on_identifier_requested(anchor, "/missing/file.usd")
             browser.tabCloseRequested.emit(0)  # request closing our first tab
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -96,7 +96,7 @@ class TestViews(unittest.TestCase):
 
     def tearDown(self) -> None:
         cook.Repository.reset(self._token)
-        # shutil.rmtree(self._tmpf)
+        shutil.rmtree(self._tmpf)
 
     def test_layer_composition(self):
         widget = description.LayerStackComposition()
@@ -393,7 +393,7 @@ class TestViews(unittest.TestCase):
             first_browser_widget._format_options.setCurrentIndex(1)
             first_browser_widget._format_options.setCurrentIndex(0)
             browser._on_identifier_requested(anchor, layers[1].identifier)
-            with mock.patch("PySide6.QtWidgets.QMessageBox.warning", new=_log):
+            with mock.patch("PySide2.QtWidgets.QMessageBox.warning", new=_log):
                 browser._on_identifier_requested(anchor, "/missing/file.usd")
             browser.tabCloseRequested.emit(0)  # request closing our first tab
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import io
 import csv
@@ -127,11 +128,11 @@ class TestViews(unittest.TestCase):
         self.assertEqual(1, widget._prims.model.rowCount())
 
         if not hasattr(os, "add_dll_directory"):  # add_dll_directory only on Windows
-            new_method = lambda path: print(f"Added {path}")
+            os_dll_ctx = mock.patch("os.add_dll_directory", new=lambda path: print(f"Added {path}"))
         else:
-            new_method = os.add_dll_directory
+            os_dll_ctx = contextlib.nullcontext()
 
-        with mock.patch("os.add_dll_directory", new=new_method):
+        with os_dll_ctx:
             _core._which.cache_clear()
             with mock.patch("grill.views.description._which") as patch:  # simulate dot is not in the environment
                 patch.return_value = None

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -378,7 +378,7 @@ class TestViews(unittest.TestCase):
             _to_ascii = description._format_layer_contents
 
         layers = stage.GetLayerStack()
-        args = stage.GetLayerStack(), None, stage.GetPathResolverContext()
+        args = stage.GetLayerStack(), None, stage.GetPathResolverContext(), (Sdf.Path("/"), spawned.GetPrim().GetPath(),)
         anchor = layers[0]
 
         def _log(*args):
@@ -388,7 +388,7 @@ class TestViews(unittest.TestCase):
             dialog = description._start_content_browser(*args)
             browser = dialog.findChild(description._PseudoUSDBrowser)
             browser._on_identifier_requested(anchor, layers[1].identifier)
-            with mock.patch("PySide2.QtWidgets.QMessageBox.warning", new=_log):
+            with mock.patch("PySide6.QtWidgets.QMessageBox.warning", new=_log):
                 browser._on_identifier_requested(anchor, "/missing/file.usd")
             browser.tabCloseRequested.emit(0)  # request closing our first tab
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import io
 import csv

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -127,10 +127,10 @@ class TestViews(unittest.TestCase):
         self.assertEqual(2, widget._layers.model.rowCount())
         self.assertEqual(1, widget._prims.model.rowCount())
 
-        if not hasattr(os, "add_dll_directory"):  # add_dll_directory only on Windows
-            os_dll_ctx = mock.patch("os.add_dll_directory", new=lambda path: print(f"Added {path}"))
-        else:
+        if hasattr(os, "add_dll_directory"):  # add_dll_directory only on Windows
             os_dll_ctx = contextlib.nullcontext()
+        else:
+            os_dll_ctx = mock.patch("os.add_dll_directory", new=lambda path: print(f"Added {path}"))
 
         with os_dll_ctx:
             _core._which.cache_clear()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -96,7 +96,7 @@ class TestViews(unittest.TestCase):
 
     def tearDown(self) -> None:
         cook.Repository.reset(self._token)
-        # shutil.rmtree(self._tmpf)
+        shutil.rmtree(self._tmpf)
 
     def test_layer_composition(self):
         widget = description.LayerStackComposition()


### PR DESCRIPTION
The recent updates to pygraphviz (https://github.com/thegrill/grill/pull/31) and QtCharts (https://github.com/thegrill/grill/pull/28) on the main Python-3.9+ branch left DCCs out of testing due to them stuck on Python-3.7.
Now that they bundle Python-3.9, integration with DCCs can happen again.

Houdini-19.5 - Prim Composition
![hou_39_integration09_prim_comp](https://user-images.githubusercontent.com/8294116/223416152-d7c456d1-6995-48e4-93e0-a89f89200d4e.gif)

Houdini-19.5 - Layer Stack Composition
![hou_39_integration10_layer_stack](https://user-images.githubusercontent.com/8294116/223416191-b0ffa364-2f7f-48bd-a473-127c76f8d98b.gif)

Updated `Layer Content Browser` to have `Format` output options (before it was `pseudoLayer` only, now it allows for `outline` and `usdtree`:

![content_browser_outline_usdview01](https://user-images.githubusercontent.com/8294116/231415967-c960d036-05e6-42d3-905f-d673f8cf2579.gif)
