### PR TITLE
Pin Sphinx<9 for doc builds

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -266,13 +266,22 @@ def _get_url_for_usd_target(app, target):
     pxr_obj_namespace = target.removeprefix('pxr.').replace(".", "")
     pxr_obj_namespace = {
         "UsdInitialLoadSet": "UsdStage::InitialLoadSet",   # there's indirection in the python bindings
-        "UsdFilter": "UsdPrimCompositionQuery::Filter",    # filter is a member of the query type
+        # nested PrimCompositionQuery types (pxr.Usd.PrimCompositionQuery.* -> UsdPrimCompositionQuery*)
+        "UsdPrimCompositionQueryFilter": "UsdPrimCompositionQuery::Filter",
+        "UsdPrimCompositionQueryDependencyTypeFilter": "UsdPrimCompositionQuery::DependencyTypeFilter",
+        "UsdPrimCompositionQueryArcTypeFilter": "UsdPrimCompositionQuery::ArcTypeFilter",
+        "UsdPrimCompositionQueryArcIntroducedFilter": "UsdPrimCompositionQuery::ArcIntroducedFilter",
+        "UsdPrimCompositionQueryHasSpecsFilter": "UsdPrimCompositionQuery::HasSpecsFilter",
+        "UsdFilter": "UsdPrimCompositionQuery::Filter",    # legacy alias
         "UsdCompositionArc": "UsdPrimCompositionQueryArc",
         "Usd_Term": "primFlags.h",
         "Usd_PrimFlagsConjunction": "primFlags.h",
     }.get(pxr_obj_namespace, pxr_obj_namespace)
     part = _get_doxylink_part(pxr_obj_namespace)
-    url = app.env.doxylink_cache[_USD_DOXYGEN_CACHE_NAME]['mapping'][part]
+    try:
+        url = app.env.doxylink_cache[_USD_DOXYGEN_CACHE_NAME]['mapping'][part]
+    except LookupError:
+        return None
     full_url = _doxylink_ext.join(_USD_DOXYGEN_ROOT_DIR, url.file)
     reftitle = _get_usd_ref_tooltip(app)
     return part + " " + reftitle, full_url
@@ -282,8 +291,9 @@ def _handle_missing_usd_reference(app, env, node, contnode):
     from docutils import nodes
 
     if (target := node['reftarget']).startswith('pxr.'):
-        reftitle, refuri = _get_url_for_usd_target(app, target)
-        return nodes.reference('', contnode.astext(), internal=False, refuri=refuri, reftitle=reftitle)
+        if result := _get_url_for_usd_target(app, target):
+            reftitle, refuri = result
+            return nodes.reference('', contnode.astext(), internal=False, refuri=refuri, reftitle=reftitle)
 
 
 def _grill_process_signature(app, what, name, obj, options, signature, return_annotation):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -265,7 +265,8 @@ def _get_usd_ref_tooltip(app):
 def _get_url_for_usd_target(app, target):
     pxr_obj_namespace = target.removeprefix('pxr.').replace(".", "")
     pxr_obj_namespace = {
-        "UsdInitialLoadSet": "UsdStage::InitialLoadSet",   # there's indirection in the python bindings
+        "UsdStageInitialLoadSet": "UsdStage::InitialLoadSet",  # pxr.Usd.Stage.InitialLoadSet
+        "UsdInitialLoadSet": "UsdStage::InitialLoadSet",       # legacy alias
         # nested PrimCompositionQuery types (pxr.Usd.PrimCompositionQuery.* -> UsdPrimCompositionQuery*)
         "UsdPrimCompositionQueryFilter": "UsdPrimCompositionQuery::Filter",
         "UsdPrimCompositionQueryDependencyTypeFilter": "UsdPrimCompositionQuery::DependencyTypeFilter",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -264,16 +264,13 @@ def _get_usd_ref_tooltip(app):
 @functools.cache
 def _get_url_for_usd_target(app, target):
     pxr_obj_namespace = target.removeprefix('pxr.').replace(".", "")
+    # Some doxylink urls from python binding members not map directly yet.
+    # Add entries here for exceptions such as: LookupError: No documentation entry matching "UsdStageInitialLoadSet"
+    # Enclosed as:
+    # sphinx.errors.ExtensionError: Handler <function _handle_missing_usd_reference at 0x000001C8C34A5B10> for event 'missing-reference' threw an exception (exception: No documentation entry matching "UsdStageInitialLoadSet")
     pxr_obj_namespace = {
-        "UsdStageInitialLoadSet": "UsdStage::InitialLoadSet",  # pxr.Usd.Stage.InitialLoadSet
-        "UsdInitialLoadSet": "UsdStage::InitialLoadSet",       # legacy alias
-        # nested PrimCompositionQuery types (pxr.Usd.PrimCompositionQuery.* -> UsdPrimCompositionQuery*)
+        "UsdStageInitialLoadSet": "UsdStage::InitialLoadSet",
         "UsdPrimCompositionQueryFilter": "UsdPrimCompositionQuery::Filter",
-        "UsdPrimCompositionQueryDependencyTypeFilter": "UsdPrimCompositionQuery::DependencyTypeFilter",
-        "UsdPrimCompositionQueryArcTypeFilter": "UsdPrimCompositionQuery::ArcTypeFilter",
-        "UsdPrimCompositionQueryArcIntroducedFilter": "UsdPrimCompositionQuery::ArcIntroducedFilter",
-        "UsdPrimCompositionQueryHasSpecsFilter": "UsdPrimCompositionQuery::HasSpecsFilter",
-        "UsdFilter": "UsdPrimCompositionQuery::Filter",    # legacy alias
         "UsdCompositionArc": "UsdPrimCompositionQueryArc",
         "Usd_Term": "primFlags.h",
         "Usd_PrimFlagsConjunction": "primFlags.h",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -278,10 +278,7 @@ def _get_url_for_usd_target(app, target):
         "Usd_PrimFlagsConjunction": "primFlags.h",
     }.get(pxr_obj_namespace, pxr_obj_namespace)
     part = _get_doxylink_part(pxr_obj_namespace)
-    try:
-        url = app.env.doxylink_cache[_USD_DOXYGEN_CACHE_NAME]['mapping'][part]
-    except LookupError:
-        return None
+    url = app.env.doxylink_cache[_USD_DOXYGEN_CACHE_NAME]['mapping'][part]
     full_url = _doxylink_ext.join(_USD_DOXYGEN_ROOT_DIR, url.file)
     reftitle = _get_usd_ref_tooltip(app)
     return part + " " + reftitle, full_url
@@ -291,9 +288,8 @@ def _handle_missing_usd_reference(app, env, node, contnode):
     from docutils import nodes
 
     if (target := node['reftarget']).startswith('pxr.'):
-        if result := _get_url_for_usd_target(app, target):
-            reftitle, refuri = result
-            return nodes.reference('', contnode.astext(), internal=False, refuri=refuri, reftitle=reftitle)
+        reftitle, refuri = _get_url_for_usd_target(app, target)
+        return nodes.reference('', contnode.astext(), internal=False, refuri=refuri, reftitle=reftitle)
 
 
 def _grill_process_signature(app, what, name, obj, options, signature, return_annotation):

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ include = grill.*
 # conda install conda-forge::graphviz=11 # 13.1.2 brings up libffi which messes up _ctypes from python-3.13, and 12 fails to load gvplugin_pango.dll
 # python -m pip install grill-names>=2.6.0 networkx>=3.4 pydot>=3.0.1 numpy PyOpenGL pyside6
 # docs dependencies:
-# python -m pip install sphinx myst-parser sphinx-toggleprompt sphinx-copybutton sphinx-togglebutton sphinx-hoverxref>=1.4.1 sphinx_autodoc_typehints sphinx-inline-tabs shibuya sphinxcontrib-doxylink
+# python -m pip install -U "sphinx>=7.2,<9" myst-parser sphinx-toggleprompt sphinx-copybutton sphinx-togglebutton "sphinx-hoverxref>=1.4.1" sphinx_autodoc_typehints sphinx-inline-tabs shibuya sphinxcontrib-doxylink
 # For EDGEDB (coming up)
 # python -m pip install edgedb
 # To install packages in editable mode, cd to desired package repo, then:

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,17 @@ include = grill.*
 # To install packages in editable mode, cd to desired package repo, then:
 # python -m pip install -e .
 
-docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx-hoverxref>=1.4.1; sphinx_autodoc_typehints; sphinx-inline-tabs; shibuya; usd-core; sphinxcontrib-doxylink
+docs =
+    sphinx>=7.2,<9
+    myst-parser
+    sphinx-toggleprompt
+    sphinx-copybutton
+    sphinx-togglebutton
+    sphinx-hoverxref>=1.4.1,<2
+    sphinx_autodoc_typehints
+    sphinx-inline-tabs
+    shibuya
+    usd-core
+    sphinxcontrib-doxylink
 full = PySide6; usd-core; PyOpenGL
 create = grill-names>=2.6.0


### PR DESCRIPTION
- Pin `sphinx>=7.2,<9` as 9 causes a failure:
  ```python
   sphinx.errors.ExtensionError: Handler <function deprecated_configs_warning at 0x7c5433104fe0> for event 'config-inited' threw an exception (exception: cannot unpack non-iterable _Opt object)
   ```
  which comes through `sphinx-hoverxref` (which has been archived) relying on `_Opt` config API.

- Local docs build: `pip install -e .[docs,create]` then `python docs/source/build_docs.py`